### PR TITLE
Fix leaderboard image shrinking (and small refactoring of css)

### DIFF
--- a/app/assets/stylesheets/games/index.scss
+++ b/app/assets/stylesheets/games/index.scss
@@ -159,8 +159,6 @@
   justify-content: space-between;
 }
 
-
-
 .menu-leaderboard-avatar {
   border: 1px solid rgba(47, 79, 79, 0.6);
   border-radius: 50%;
@@ -180,19 +178,6 @@
 
   }
 }
-
-// .default-menu-leaderboard-avatar {
-//   border: 1px solid rgba(47, 79, 79, 0.6);
-//   border-radius: 50%;
-//   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
-//   height: 40px;
-//   width: 40px;
-//   flex-shrink: 0;
-//   display: flex;
-//   justify-content: center;
-//   margin: 6px;
-// }
-
 
 .menu-leaderboard-rank {
   border: 1px solid lightgrey;

--- a/app/assets/stylesheets/games/index.scss
+++ b/app/assets/stylesheets/games/index.scss
@@ -159,31 +159,39 @@
   justify-content: space-between;
 }
 
+
+
 .menu-leaderboard-avatar {
   border: 1px solid rgba(47, 79, 79, 0.6);
   border-radius: 50%;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
   height: 40px;
   width: 40px;
+  flex-shrink: 0;
   display: flex;
   justify-content: center;
   margin: 6px;
+
+  &.default-avatar {
+    font-size: 30px;
+    align-items: center;
+    background-color: aliceblue;
+    padding: 5px;
+
+  }
 }
 
-.default-menu-leaderboard-avatar {
-  border: 1px solid rgba(47, 79, 79, 0.6);
-  font-size: 30px;
-  border-radius: 50%;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
-  height: 40px;
-  width: 40px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: aliceblue;
-  padding: 5px;
-  margin: 6px;
-}
+// .default-menu-leaderboard-avatar {
+//   border: 1px solid rgba(47, 79, 79, 0.6);
+//   border-radius: 50%;
+//   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+//   height: 40px;
+//   width: 40px;
+//   flex-shrink: 0;
+//   display: flex;
+//   justify-content: center;
+//   margin: 6px;
+// }
 
 
 .menu-leaderboard-rank {

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -89,7 +89,7 @@
           <% if user.avatar.attached? %>
           <%= cl_image_tag user.avatar.key, class: 'menu-leaderboard-avatar' %>
           <% else %>
-          <div class="default-menu-leaderboard-avatar">
+          <div class="menu-leaderboard-avatar default-avatar">
             <%= user.default_avatar %>
           </div>
           <% end %>


### PR DESCRIPTION
Fixes the image leaderboard shrinking, (and added a small refactoring to re-use the `.menu-leaderboard-avatar` instead of having the same css twice)